### PR TITLE
feat: add orm models and alembic baseline

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -6,3 +6,5 @@
 - Notes:
   - Keep PRs under 500 lines.
   - Update OpenAPI examples after /events implemented.
+- Implemented M2-DB: added Alembic baseline + SQLAlchemy ORM with pytest coverage (Context7 #1, #3, #6).
+- Next: wire API endpoints once DB verified (Context7 #4, #7).

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
-  "last_updated": "2025-09-21T00:00:00Z",
-  "step": 0,
-  "last_task_id": null,
+  "last_updated": "2025-09-21T00:30:00Z",
+  "step": 1,
+  "last_task_id": "M2-DB",
   "coverage_backend": 0.0,
   "coverage_web": 0.0,
   "branch": null

--- a/apps/backend/alembic.ini
+++ b/apps/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite+pysqlite:///./signalos.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.db.models import Base  # noqa: E402
+
+config = context.config
+
+if config.config_file_name:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_database_url() -> str:
+    return os.getenv("DATABASE_URL") or config.get_main_option("sqlalchemy.url")
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=get_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = get_database_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        future=True,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/backend/alembic/versions/20250921_000001_initial.py
+++ b/apps/backend/alembic/versions/20250921_000001_initial.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20250921_000001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "incidents",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("last_event_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_incidents_user_id", "incidents", ["user_id"], unique=False)
+
+    op.create_table(
+        "events",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("source", sa.String(length=64), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("entity_type", sa.String(length=64), nullable=False),
+        sa.Column("entity_id", sa.String(length=128), nullable=False),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("severity_raw", sa.String(length=32), nullable=True),
+        sa.Column("links", sa.JSON(), nullable=False),
+        sa.Column("extras", sa.JSON(), nullable=False),
+        sa.Column("features", sa.JSON(), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("explain", sa.JSON(), nullable=False),
+        sa.Column("incident_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(["incident_id"], ["incidents.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_events_incident_id", "events", ["incident_id"], unique=False)
+    op.create_index("ix_events_source", "events", ["source"], unique=False)
+    op.create_index("ix_events_occurred_at", "events", ["occurred_at"], unique=False)
+    op.create_index(
+        "ix_events_entity_window",
+        "events",
+        ["entity_type", "entity_id", "occurred_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "event_tags",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("value", sa.String(length=64), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "value", name="uq_event_tags_value"),
+    )
+    op.create_index("ix_event_tags_event_id", "event_tags", ["event_id"], unique=False)
+
+    op.create_table(
+        "event_metrics",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("value", sa.Float(), nullable=False),
+        sa.Column("unit", sa.String(length=32), nullable=True),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_event_metrics_event_id", "event_metrics", ["event_id"], unique=False)
+    op.create_index("ix_event_metrics_name", "event_metrics", ["name"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_event_metrics_name", table_name="event_metrics")
+    op.drop_index("ix_event_metrics_event_id", table_name="event_metrics")
+    op.drop_table("event_metrics")
+
+    op.drop_index("ix_event_tags_event_id", table_name="event_tags")
+    op.drop_table("event_tags")
+
+    op.drop_index("ix_events_entity_window", table_name="events")
+    op.drop_index("ix_events_occurred_at", table_name="events")
+    op.drop_index("ix_events_source", table_name="events")
+    op.drop_index("ix_events_incident_id", table_name="events")
+    op.drop_table("events")
+
+    op.drop_index("ix_incidents_user_id", table_name="incidents")
+    op.drop_table("incidents")

--- a/apps/backend/app/db/__init__.py
+++ b/apps/backend/app/db/__init__.py
@@ -1,0 +1,13 @@
+from .models import Base, Event, EventMetric, EventTag, Incident
+from .session import SessionLocal, get_engine, get_session
+
+__all__ = [
+    "Base",
+    "Event",
+    "EventMetric",
+    "EventTag",
+    "Incident",
+    "SessionLocal",
+    "get_engine",
+    "get_session",
+]

--- a/apps/backend/app/db/models.py
+++ b/apps/backend/app/db/models.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, JSON, String, Text, UniqueConstraint, UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Declarative base for all ORM models."""
+
+
+class Incident(Base):
+    __tablename__ = "incidents"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(32), default="open", nullable=False)
+    score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_event_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    events: Mapped[list["Event"]] = relationship(back_populates="incident", cascade="all, delete-orphan")
+
+
+class Event(Base):
+    __tablename__ = "events"
+    __table_args__ = (
+        Index("ix_events_occurred_at", "occurred_at"),
+        Index("ix_events_entity_window", "entity_type", "entity_id", "occurred_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    source: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    entity_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    type: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    severity_raw: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    links: Mapped[list[dict[str, Any]]] = mapped_column(JSON, default=list, nullable=False)
+    extras: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict, nullable=False)
+    features: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict, nullable=False)
+    score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    explain: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict, nullable=False)
+    incident_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("incidents.id"), nullable=True, index=True)
+
+    incident: Mapped["Incident"] = relationship(back_populates="events")
+    metrics: Mapped[list["EventMetric"]] = relationship(back_populates="event", cascade="all, delete-orphan")
+    tag_rows: Mapped[list["EventTag"]] = relationship(back_populates="event", cascade="all, delete-orphan")
+
+    @property
+    def tags(self) -> list[str]:
+        return [tag.value for tag in self.tag_rows]
+
+
+class EventTag(Base):
+    __tablename__ = "event_tags"
+    __table_args__ = (UniqueConstraint("event_id", "value", name="uq_event_tags_value"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False, index=True)
+    value: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    event: Mapped["Event"] = relationship(back_populates="tag_rows")
+
+
+class EventMetric(Base):
+    __tablename__ = "event_metrics"
+    __table_args__ = (Index("ix_event_metrics_name", "name"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    value: Mapped[float] = mapped_column(Float, nullable=False)
+    unit: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    event: Mapped["Event"] = relationship(back_populates="metrics")

--- a/apps/backend/app/db/session.py
+++ b/apps/backend/app/db/session.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+DEFAULT_SQLITE_URL = "sqlite+pysqlite:///./signalos.db"
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, future=True)
+_engine: Engine | None = None
+
+
+def get_database_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+    host = os.getenv("POSTGRES_HOST")
+    if host:
+        user = os.getenv("POSTGRES_USER", "signal")
+        password = os.getenv("POSTGRES_PASSWORD", "signal")
+        database = os.getenv("POSTGRES_DB", "signalos")
+        return f"postgresql+psycopg://{user}:{password}@{host}/{database}"
+    return DEFAULT_SQLITE_URL
+
+
+def get_engine(url: str | None = None) -> Engine:
+    global _engine
+    resolved = url or get_database_url()
+    if _engine is None or str(_engine.url) != resolved:
+        _engine = create_engine(resolved, echo=False, future=True, pool_pre_ping=True)
+        SessionLocal.configure(bind=_engine)
+    return _engine
+
+
+def get_session() -> Generator[Session, None, None]:
+    get_engine()
+    session: Session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/apps/backend/app/tests/test_db_models.py
+++ b/apps/backend/app/tests/test_db_models.py
@@ -14,7 +14,9 @@ from app.db.models import Event, EventMetric, EventTag, Incident
 
 
 def _alembic_config(db_url: str) -> Config:
-    cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
+    project_root = Path(__file__).resolve().parents[2]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "alembic"))
     cfg.set_main_option("sqlalchemy.url", db_url)
     return cfg
 

--- a/apps/backend/app/tests/test_db_models.py
+++ b/apps/backend/app/tests/test_db_models.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+
+from app.db.models import Event, EventMetric, EventTag, Incident
+
+
+def _alembic_config(db_url: str) -> Config:
+    cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+@pytest.fixture()
+def migrated_engine(tmp_path, monkeypatch):
+    db_url = f"sqlite+pysqlite:///{tmp_path/'test.db'}"
+    cfg = _alembic_config(db_url)
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    command.upgrade(cfg, "head")
+    engine = create_engine(db_url, future=True)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        command.downgrade(cfg, "base")
+
+
+def test_event_crud_round_trip(migrated_engine):
+    SessionLocal = sessionmaker(bind=migrated_engine, expire_on_commit=False, future=True)
+    incident_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    with SessionLocal() as session:
+        incident = Incident(
+            id=incident_id,
+            user_id=uuid.uuid4(),
+            status="open",
+            score=0.72,
+            summary="Elevated resting heart rate",
+            last_event_at=now,
+        )
+        event = Event(
+            source="fitbit",
+            occurred_at=now,
+            received_at=now,
+            entity_type="user",
+            entity_id="user-123",
+            type="health_alert",
+            title="Resting HR high",
+            body="Resting heart rate increased to 80 bpm.",
+            severity_raw="medium",
+            links=[{"href": "https://example.com", "rel": "source"}],
+            extras={"raw_event_id": "evt-1"},
+            features={"resting_hr_z": 2.1},
+            score=0.72,
+            explain={"resting_hr": 0.5},
+            incident=incident,
+        )
+        event.tag_rows = [EventTag(value="health"), EventTag(value="fitbit")]
+        event.metrics = [EventMetric(name="resting_hr", value=80.0, unit="bpm")]
+        session.add(event)
+        session.commit()
+        event_id = event.id
+
+    with SessionLocal() as session:
+        stored = session.get(Event, event_id)
+        assert stored is not None
+        assert stored.incident_id == incident_id
+        assert {tag.value for tag in stored.tag_rows} == {"health", "fitbit"}
+        assert stored.metrics[0].name == "resting_hr"
+        stored.score = 0.9
+        stored.links = stored.links + [{"href": "https://example.com/details", "rel": "details"}]
+        session.commit()
+
+    with SessionLocal() as session:
+        stored = session.get(Event, event_id)
+        assert stored.score == pytest.approx(0.9)
+        assert len(stored.links) == 2
+        session.delete(stored)
+        session.commit()
+        assert session.get(Event, event_id) is None
+
+
+def test_migration_downgrade_clears_schema(tmp_path, monkeypatch):
+    db_url = f"sqlite+pysqlite:///{tmp_path/'downgrade.db'}"
+    cfg = _alembic_config(db_url)
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "base")
+
+    engine = create_engine(db_url, future=True)
+    try:
+        tables = inspect(engine).get_table_names()
+        assert "events" not in tables
+        assert "incidents" not in tables
+    finally:
+        engine.dispose()

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -1,19 +1,9 @@
 version: 1
-updated_at: "2025-09-21T00:00:00Z"
+updated_at: "2025-09-21T00:30:00Z"
 milestone: M2_e2e_path
 priority_scale: [P0, P1, P2, P3]
 
 backlog:
-  - id: M2-DB
-    title: "Implement SQLAlchemy models & Alembic migrations"
-    status: todo
-    priority: P0
-    depends_on: []
-    est_hours: 3
-    acceptance:
-      - "Alembic migration applies and downgrades cleanly"
-      - "CRUD unit tests pass"
-
   - id: M2-API
     title: "Add /events (POST/GET) and /incidents (GET) with validation"
     status: todo
@@ -56,6 +46,19 @@ backlog:
       - "black/ruff/mypy clean"
 
 in_progress: []
-done: []
+
+done:
+  - id: M2-DB
+    title: "Implement SQLAlchemy models & Alembic migrations"
+    status: done
+    priority: P0
+    depends_on: []
+    est_hours: 3
+    acceptance:
+      - "Alembic migration applies and downgrades cleanly"
+      - "CRUD unit tests pass"
+    notes:
+      - "Initial migrations + ORM coverage landed via pytest"
+
 notes:
   - "Codex should add any discovered sub-tasks here as it works."


### PR DESCRIPTION
## Summary
- add SQLAlchemy ORM models for incidents, events, tags, and metrics with session helpers
- bootstrap Alembic configuration and initial migration matching CES schema
- cover migrations and CRUD flows with pytest round-trip tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cfbc5636208328b98e96cf8dbcdecc