### PR TITLE
fix: stabilize web docker build prerequisites

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
-COPY package.json package-lock.json* ./
-RUN npm ci || npm i
+COPY package*.json ./
+RUN npm ci --no-audit --no-fund || npm install --no-audit --no-fund
 
 FROM node:20-alpine AS build
 WORKDIR /app


### PR DESCRIPTION
## Summary
- add a placeholder file so the Next.js public directory is always present during container builds
- adjust the web Dockerfile to copy package manifests more defensively and fall back to npm install without audit prompts

## Testing
- npm test -- --runInBand *(fails: missing jest-environment-jsdom; existing dependency set is incomplete in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68cfdb5ac6a48328b027a8330ebad6a1