### PR TITLE
feat: inline event pipeline with scoring and correlation

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -10,3 +10,4 @@
 - Next: wire API endpoints once DB verified (Context7 #4, #7).
 - Drafted M2-API FastAPI schemas plus /events + /incidents routes with validation and pagination tests (Context7 #1, #3, #7).
 - Completed M2-API: expanded filter coverage, refreshed docs, and ensured incident timelines update on ingest (Context7 #1, #3, #6, #7). Follow-up: kick off inline worker for features→scoring pipeline (Context7 #4, #5, #6).
+- Completed M2-PIPE: wired inline enrichment to compute features, scores, explanations, and correlation on POST with regression tests covering incident merges (Context7 #1, #4, #5, #6). Follow-up: shift to web UI consuming the live API (Context7 #7).

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "last_updated": "2025-09-21T02:30:00Z",
-  "step": 3,
-  "last_task_id": "M2-API",
+  "last_updated": "2025-09-21T04:00:00Z",
+  "step": 4,
+  "last_task_id": "M2-PIPE",
   "coverage_backend": 0.0,
   "coverage_web": 0.0,
-  "branch": "feat/M2-API"
+  "branch": "feat/M2-PIPE"
 }

--- a/apps/backend/app/ingest/pipeline.py
+++ b/apps/backend/app/ingest/pipeline.py
@@ -112,12 +112,13 @@ def _explain_score(features: dict[str, float], score_value: float) -> dict[str, 
 
 def _correlate(event: EventCreate, score_value: float, session: Session) -> UUID | None:
     lookback_start = event.occurred_at - timedelta(minutes=15)
+    lookahead_end = event.occurred_at + timedelta(minutes=15)
     new_view = _event_view(event)
     stmt = (
         select(EventModel)
         .options(selectinload(EventModel.tag_rows))
         .where(EventModel.occurred_at >= lookback_start)
-        .where(EventModel.occurred_at <= event.occurred_at)
+        .where(EventModel.occurred_at <= lookahead_end)
         .order_by(EventModel.occurred_at.desc())
         .limit(50)
     )

--- a/apps/backend/app/ingest/pipeline.py
+++ b/apps/backend/app/ingest/pipeline.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.api.schemas import EventCreate
+from app.db import Event as EventModel, Incident
+from app.services.correlate import should_merge
+from app.services.features import feature_vector
+from app.services.scoring import score
+
+
+@dataclass
+class PipelineResult:
+    """Outcome of running the inline enrichment pipeline for an event."""
+
+    features: dict[str, float]
+    score: float
+    explain: dict[str, Any]
+    incident_id: UUID | None
+
+
+def process_event(event: EventCreate, session: Session) -> PipelineResult:
+    """Run feature extraction, scoring, and correlation for an incoming event."""
+
+    metrics = _metrics_dict(event)
+    context = _build_context(event)
+    feature_values = feature_vector({"type": event.type, "metrics": metrics}, context)
+    score_value = score(feature_values)
+    explanation = _explain_score(feature_values, score_value)
+    incident_id = event.incident_id or _correlate(event, score_value, session)
+    return PipelineResult(
+        features=feature_values,
+        score=score_value,
+        explain=explanation,
+        incident_id=incident_id,
+    )
+
+
+def _metrics_dict(event: EventCreate) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for metric in event.metrics:
+        try:
+            metrics[metric.name] = float(metric.value)
+        except (TypeError, ValueError):  # pragma: no cover - validated upstream
+            continue
+    return metrics
+
+
+def _build_context(event: EventCreate) -> dict[str, Any]:
+    extras = event.extras or {}
+    context: dict[str, Any] = {}
+
+    nested = extras.get("context")
+    if isinstance(nested, dict):
+        context.update(nested)
+
+    context.setdefault("portfolio_exposure", _as_float(extras.get("portfolio_exposure"), 1.0))
+    context.setdefault("market_open", _as_bool(extras.get("market_open"), True))
+    context.setdefault("personal_relevance", _as_float(extras.get("personal_relevance"), 0.5))
+    return context
+
+
+def _as_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in {"true", "True", "1", 1}:
+        return True
+    if value in {"false", "False", "0", 0}:
+        return False
+    return default
+
+
+def _explain_score(features: dict[str, float], score_value: float) -> dict[str, Any]:
+    impact = max(
+        features.get("impact_finance", 0.0),
+        features.get("impact_health", 0.0),
+        features.get("impact_news", 0.0),
+    )
+    factors = {
+        "impact": impact,
+        "actionability": features.get("actionability", 0.5),
+        "urgency": features.get("urgency", 0.2),
+        "personal_relevance": features.get("personal_relevance", 0.5),
+    }
+    weights = {
+        "impact": 0.4,
+        "actionability": 0.25,
+        "urgency": 0.2,
+        "personal_relevance": 0.15,
+    }
+    contributions = {name: round(value * weights[name], 6) for name, value in factors.items()}
+    top_factor = max(contributions.items(), key=lambda item: item[1])[0] if contributions else None
+    return {
+        "contributions": contributions,
+        "top_factor": top_factor,
+        "score": round(score_value, 6),
+    }
+
+
+def _correlate(event: EventCreate, score_value: float, session: Session) -> UUID | None:
+    lookback_start = event.occurred_at - timedelta(minutes=15)
+    new_view = _event_view(event)
+    stmt = (
+        select(EventModel)
+        .options(selectinload(EventModel.tag_rows))
+        .where(EventModel.occurred_at >= lookback_start)
+        .where(EventModel.occurred_at <= event.occurred_at)
+        .order_by(EventModel.occurred_at.desc())
+        .limit(50)
+    )
+    candidates = session.execute(stmt).unique().scalars().all()
+    for candidate in candidates:
+        candidate_view = _event_view(candidate)
+        if should_merge(candidate_view, new_view):
+            if candidate.incident_id is not None:
+                incident = session.get(Incident, candidate.incident_id)
+                if incident is None or incident.status != "open":
+                    continue
+                _update_incident(incident, score_value, event.occurred_at)
+                return incident.id
+            incident = Incident(status="open")
+            session.add(incident)
+            session.flush()
+            candidate.incident_id = incident.id
+            _update_incident(incident, candidate.score, candidate.occurred_at)
+            _update_incident(incident, score_value, event.occurred_at)
+            return incident.id
+    return None
+
+
+def _event_view(event: EventCreate | EventModel) -> dict[str, Any]:
+    if isinstance(event, EventCreate):
+        occurred_at = event.occurred_at
+        tags = event.tags
+        entity_id = event.entity.id
+    else:
+        occurred_at = event.occurred_at
+        tags = [tag.value for tag in event.tag_rows]
+        entity_id = event.entity_id
+    occurred_ms = int(occurred_at.timestamp() * 1000)
+    return {"entity_id": entity_id, "occurred_at": occurred_ms, "tags": tags}
+
+
+def _update_incident(incident: Incident, score_value: float | None, occurred_at: datetime) -> None:
+    if score_value is not None:
+        if incident.score is None or score_value > incident.score:
+            incident.score = score_value
+    normalized_occurred = _to_utc(occurred_at)
+    last_event = incident.last_event_at
+    if last_event is None or normalized_occurred > _to_utc(last_event):
+        incident.last_event_at = normalized_occurred
+
+
+def _to_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -1,19 +1,9 @@
 version: 1
-updated_at: "2025-09-21T02:30:00Z"
+updated_at: "2025-09-21T04:00:00Z"
 milestone: M2_e2e_path
 priority_scale: [P0, P1, P2, P3]
 
 backlog:
-  - id: M2-PIPE
-    title: "Inline worker: features → score → explain → correlate"
-    status: todo
-    priority: P0
-    depends_on: [M2-API]
-    est_hours: 4
-    acceptance:
-      - "On POST, event scored and optionally merged to incident"
-      - "Unit + integration tests green"
-
   - id: M2-WEB
     title: "Web UI fetch /events & /incidents (replace demo)"
     status: todo
@@ -61,6 +51,18 @@ done:
       - "OpenAPI examples added"
     notes:
       - "Hardened filters plus incident timestamp upkeep with integration tests and docs updates (Context7 #1, #3, #6, #7)."
+
+  - id: M2-PIPE
+    title: "Inline worker: features → score → explain → correlate"
+    status: done
+    priority: P0
+    depends_on: [M2-API]
+    est_hours: 4
+    acceptance:
+      - "On POST, event scored and optionally merged to incident"
+      - "Unit + integration tests green"
+    notes:
+      - "Inline enrichment now computes features, scoring, and correlation with regression tests (Context7 #1, #4, #5, #6)."
 
 notes:
   - "Codex should add any discovered sub-tasks here as it works."


### PR DESCRIPTION
## Summary
- add an inline enrichment pipeline for events that computes features, scores, explanations, and correlation targets
- update the events POST handler to invoke the pipeline and refresh incident metadata as events arrive
- extend API tests for the enrichment flow and refresh TODO/state tracking files

## Testing
- pytest apps/backend/app/tests -q

------
https://chatgpt.com/codex/tasks/task_b_68dcc19f164c8328b8ad13aa0aa7118b